### PR TITLE
Replace strcpy with strncpy, sprintf with snprintf

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -95,7 +95,7 @@ CJSON_PUBLIC(char *) cJSON_GetStringValue(cJSON *item) {
 CJSON_PUBLIC(const char*) cJSON_Version(void)
 {
     static char version[15];
-    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+    snprintf(version, sizeof(version), "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
 
     return version;
 }
@@ -499,22 +499,22 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if ((d * 0) != 0)
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "null");
     }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.15g", d);
 
         /* Check whether the original double can be recovered */
         if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || ((double)test != d))
         {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.17g", d);
         }
     }
 
-    /* sprintf failed or buffer overrun occurred */
+    /* snprintf failed or buffer overrun occurred */
     if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;
@@ -848,15 +848,16 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
         return false;
     }
 
+    const char quotes[] = "\"\"";
     /* empty string */
     if (input == NULL)
     {
-        output = ensure(output_buffer, sizeof("\"\""));
+        output = ensure(output_buffer, sizeof(quotes));
         if (output == NULL)
         {
             return false;
         }
-        strcpy((char*)output, "\"\"");
+        strncpy((char*)output, quotes, output_buffer->length - output_buffer->offset);
 
         return true;
     }
@@ -887,7 +888,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
     }
     output_length = (size_t)(input_pointer - input) + escape_characters;
 
-    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    output = ensure(output_buffer, output_length + sizeof(quotes));
     if (output == NULL)
     {
         return false;
@@ -943,7 +944,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    snprintf((char*)output_pointer, output_buffer->length - (output_pointer - output_buffer->buffer), "u%04x", *input_pointer);
                     output_pointer += 4;
                     break;
             }
@@ -1286,32 +1287,38 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
     switch ((item->type) & 0xFF)
     {
         case cJSON_NULL:
-            output = ensure(output_buffer, 5);
+        {
+            const char buff[] = "null";
+            output = ensure(output_buffer, sizeof(buff));
             if (output == NULL)
             {
                 return false;
             }
-            strcpy((char*)output, "null");
+            strncpy((char*)output, buff, output_buffer->length - output_buffer->offset);
             return true;
-
+        }
         case cJSON_False:
-            output = ensure(output_buffer, 6);
+        {
+            const char buff[] = "false";
+            output = ensure(output_buffer, sizeof(buff));
             if (output == NULL)
             {
                 return false;
             }
-            strcpy((char*)output, "false");
+            strncpy((char*)output, buff, output_buffer->length - output_buffer->offset);
             return true;
-
+        }
         case cJSON_True:
-            output = ensure(output_buffer, 5);
+        {
+            const char buff[] = "true";
+            output = ensure(output_buffer, sizeof(buff));
             if (output == NULL)
             {
                 return false;
             }
-            strcpy((char*)output, "true");
+            strncpy((char*)output, buff, output_buffer->length - output_buffer->offset);
             return true;
-
+        }
         case cJSON_Number:
             return print_number(item, output_buffer);
 


### PR DESCRIPTION
This change is based on static analyzer report that flagged strcpy and sprintf in cJSON, even though there are being used carefully without problem. We want the upstream maintainer to review this change and get their feedback first then to update our current code base with missing updates from upstream as well. 

- [x] Finish my changes
- [x] Push my commits to GitHub
- [x] Open a pull request